### PR TITLE
Kakao Map API 활용 및 지도 페이지 구현

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,11 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>StopMoving😎</title>
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=1f4d909dcb7ba520e60798a157115c1c&libraries=services,clusterer&autoload=false"
+    ></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React from "react";
 import GlobalStyle from "./styles/GlobalStyle";
 import Login from "./pages/Login";
 import { Route, Routes } from "react-router-dom";
+import Map from "./pages/Map";
 
 const App = () => {
   return (
@@ -9,6 +10,7 @@ const App = () => {
       <GlobalStyle />
       <Routes>
         <Route path="login" element={<Login />} />
+        <Route path="map" element={<Map />} />
       </Routes>
     </>
   );

--- a/src/components/mapComponents/KakaoMap.jsx
+++ b/src/components/mapComponents/KakaoMap.jsx
@@ -1,0 +1,38 @@
+import React, { useEffect } from "react";
+import useMapStore from "../../store/useMapStore";
+
+const KakaoMap = () => {
+  const setMap = useMapStore((state) => state.setMap);
+  const BASE_LOCATION = {
+    lat: 37.505298,
+    lng: 126.957113,
+  };
+
+  useEffect(() => {
+    // kakao를 window전역객체로 설정
+    const { kakao } = window;
+    if (!kakao || !kakao.maps) return;
+
+    // map 가져오기 핵심 로직
+    kakao.maps.load(() => {
+      const mapContainer = document.getElementById("map");
+      const options = {
+        // 지도 중심부 위도 경도 입력
+        center: new kakao.maps.LatLng(BASE_LOCATION.lat, BASE_LOCATION.lng),
+        level: 3,
+      };
+
+      const mapInstance = new kakao.maps.Map(mapContainer, options);
+      setMap(mapInstance);
+    });
+
+    //클린업 함수 메모리 누수 방지
+    return () => {
+      setMap(null);
+    };
+  }, [setMap]);
+
+  return <div id="map" style={{ width: "100%", height: "100%" }}></div>;
+};
+
+export default KakaoMap;

--- a/src/components/mapComponents/LibraryMarker.jsx
+++ b/src/components/mapComponents/LibraryMarker.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const LibraryMarker = () => {
+  return <div>LibraryMarker</div>;
+};
+
+export default LibraryMarker;

--- a/src/pages/Map.jsx
+++ b/src/pages/Map.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import KakaoMap from "../components/mapComponents/KakaoMap";
+
+const Map = () => {
+  return (
+    <div style={{ position: "relative", width: "100vw", height: "100vh" }}>
+      <KakaoMap />
+    </div>
+  );
+};
+
+export default Map;

--- a/src/store/useMapStore.js
+++ b/src/store/useMapStore.js
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+const useMapStore = create((set) => ({
+  // map 상태 관리
+  map: null,
+  // 생성된 지도 객체 받아와서 덮어쓰기
+  setMap: (mapInstance) => set({ map: mapInstance }),
+
+  // marker 상태 관리
+  marker: [],
+  // 마커 인스턴스 받아와서 덮어씌워주기
+  setMarkers: (newMarkers) => set({ markers: newMarkers }),
+  // 마커 지우기
+  clearMarkers: () =>
+    set((state) => {
+      state.markers.forEach((marker) => marker.setMap(null));
+      return { marker: [] };
+    }),
+}));
+
+export default useMapStore;


### PR DESCRIPTION
1. HTML head에 (카카오 맵 API 호출 자바스크립트 key + 도서관 전용 서비스, 클러스터 객체) 추가

2. components
- KakaoMap.jsx 컴포넌트 추가. (아직 지도만 띄울 수 있음.)
- LibraryMarker.jsx 컴포넌트 추가. (추후 기능 업데이트 예정)

3. pages
- map 페이지 추가

4. store
- useMapStore.js 추가 (Map 전역 상태 관리용)